### PR TITLE
perl-5.26.0 compatibility

### DIFF
--- a/t/03chdriver.t
+++ b/t/03chdriver.t
@@ -2,7 +2,7 @@ use Test;
 BEGIN { plan tests => 12 }
 use XML::SAX::Base;
 use vars qw/%events/;
-require "t/events.pl";
+require "./t/events.pl";
 
 # Tests for ContentHandler classes
 

--- a/t/04chfilter.t
+++ b/t/04chfilter.t
@@ -2,7 +2,7 @@ use Test;
 BEGIN { plan tests => 12 }
 use XML::SAX::Base;
 use vars qw/%events/;
-require "t/events.pl";
+require "./t/events.pl";
 
 # Tests for ContentHandler classes using a filter
 

--- a/t/05dtdhdriver.t
+++ b/t/05dtdhdriver.t
@@ -3,7 +3,7 @@ BEGIN { plan tests => 7 }
 use XML::SAX::Base;
 use strict;
 use vars qw/%events $meth_count/;
-require "t/events.pl";
+require "./t/events.pl";
 
 # Tests for ContentHandler classes using a filter
 

--- a/t/06lexhdriver.t
+++ b/t/06lexhdriver.t
@@ -3,7 +3,7 @@ BEGIN { plan tests => 8 }
 use XML::SAX::Base;
 use strict;
 use vars qw/%events $meth_count/;
-require "t/events.pl";
+require "./t/events.pl";
 
 # Tests for ContentHandler classes using a filter
 

--- a/t/07declhdriver.t
+++ b/t/07declhdriver.t
@@ -3,7 +3,7 @@ BEGIN { plan tests => 5 }
 use XML::SAX::Base;
 use strict;
 use vars qw/%events $meth_count/;
-require "t/events.pl";
+require "./t/events.pl";
 
 # Tests for ContentHandler classes using a filter
 

--- a/t/08errorhdriver.t
+++ b/t/08errorhdriver.t
@@ -3,7 +3,7 @@ BEGIN { plan tests => 4 }
 use XML::SAX::Base;
 use strict;
 use vars qw/%events $meth_count/;
-require "t/events.pl";
+require "./t/events.pl";
 
 # Tests for ErrorHandler classes using a filter
 

--- a/t/09resoldriver.t
+++ b/t/09resoldriver.t
@@ -3,7 +3,7 @@ BEGIN { plan tests => 2 }
 use XML::SAX::Base;
 use strict;
 use vars qw/%events $meth_count/;
-require "t/events.pl";
+require "./t/events.pl";
 
 # Tests for EntityResolver classes using a filter
 

--- a/t/10dochdriver.t
+++ b/t/10dochdriver.t
@@ -3,7 +3,7 @@ BEGIN { plan tests => 10 }
 use XML::SAX::Base;
 use strict;
 use vars qw/%events $meth_count/;
-require "t/events.pl";
+require "./t/events.pl";
 
 # Tests for DocumentHandler classes using a filter
 

--- a/t/11sax1multiclass.t
+++ b/t/11sax1multiclass.t
@@ -3,7 +3,7 @@ BEGIN { plan tests => 16 }
 use XML::SAX::Base;
 use strict;
 use vars qw/%events $meth_count/;
-require "t/events.pl";
+require "./t/events.pl";
 
 # Multiclass SAX1 filter
 

--- a/t/12sax2multiclass.t
+++ b/t/12sax2multiclass.t
@@ -3,7 +3,7 @@ BEGIN { plan tests => 33 }
 use XML::SAX::Base;
 use strict;
 use vars qw/%events $meth_count/;
-require "t/events.pl";
+require "./t/events.pl";
 
 # Multiclass SAX1 filter
 

--- a/t/13handlerswitch.t
+++ b/t/13handlerswitch.t
@@ -3,7 +3,7 @@ BEGIN { plan tests => 3 }
 use XML::SAX::Base;
 use strict;
 use vars qw/%events $meth_count $one_count $two_count/;
-require "t/events.pl";
+require "./t/events.pl";
 
 # Tests for in-stream switch of Handler classes.
 

--- a/t/14downstreamswitch.t
+++ b/t/14downstreamswitch.t
@@ -3,7 +3,7 @@ BEGIN { plan tests => 3 }
 use XML::SAX::Base;
 use strict;
 use vars qw/%events $meth_count $one_count $two_count/;
-require "t/events.pl";
+require "./t/events.pl";
 
 $meth_count = 0;
 # Tests for in-stream switch of Handler classes.

--- a/t/15parentswitch.t
+++ b/t/15parentswitch.t
@@ -3,7 +3,7 @@ BEGIN { plan tests => 3 }
 use XML::SAX::Base;
 use strict;
 use vars qw/%events $meth_count $one_count $two_count/;
-require "t/events.pl";
+require "./t/events.pl";
 
 # Tests for in-stream switch of Handler classes.
 my $driver = Driver->new();


### PR DESCRIPTION
In perl 5.26.0, '.' will not be found by default in @INC.  This patch adjusts
tests so that a file require-d by most of the .t files can be properly
located.

For:  https://rt.cpan.org/Ticket/Display.html?id=120435